### PR TITLE
file naming convention fixed

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3,8 +3,8 @@
 env:
   CGO_ENABLED: 0
   GOARCH: amd64
-  VERSION: 0.2
-  RELEASE: 6
+  VERSION: 0.2.6
+  RELEASE: 1
 
 
 functions:

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -76,29 +76,9 @@ func GenerateKey(name, email, comment, keyType string, bits int) error {
 
 	pgp := NewPGP(name, email, comment, keyType, passPhrase, bits)
 
-	//Commented section stores keys to files, soon will be decommissioned
-	//privateKeyName := fmt.Sprintf("%s-%s", name, "priv")
-	//publicKeyName := fmt.Sprintf("%s-%s", name, "pub")
-
-	//if err := pgp.SaveKeys(privateKeyName, publicKeyName, EXTENSION); err != nil {
-	//	return err
-	//}
-
 	//Saving private/public/passphrase keys in database
 	if err := pgp.StoreKeysToDb(name); err != nil {
 		return err
 	}
 	return nil
 }
-
-//This function will be completely decommissioned
-/*func (f *FlufikPGP) SaveKeys(privName, pubName, ext string) error {
-	privateKeyPath, publicKeyPath := core.FlufikKeyFileName(privName, pubName, ext)
-	if err := ioutil.WriteFile(privateKeyPath, []byte(f.privateKey), os.ModePerm); err != nil {
-		return err
-	}
-	if err := ioutil.WriteFile(publicKeyPath, []byte(f.publicKey), os.ModePerm); err != nil {
-		return err
-	}
-	return nil
-}*/

--- a/internal/flufikbuilder/flufikrpmbuilder.go
+++ b/internal/flufikbuilder/flufikrpmbuilder.go
@@ -110,7 +110,7 @@ func (flufikRpm *FlufikRPMBuilder) FileName() (string, error) {
 		arch = flufikMeta.Arch
 	}
 
-	return fmt.Sprintf("%s-%s%s.%s.rpm", flufikMeta.Name, flufikMeta.Version, release, arch), nil
+	return fmt.Sprintf("%s-%s-%s.%s.rpm", flufikMeta.Name, flufikMeta.Version, release, arch), nil
 }
 
 func (flufikRpm *FlufikRPMBuilder) Build(writer io.Writer) error {


### PR DESCRIPTION
example:
- flufik-<v.v.v>-<r.r.r>.<arch>.rpm - flufik-0.2.6-1.el8.x86_64.rpm

- flufik_<v.v.v>-<r.r.r>_<arch>.deb - flufik_0.2.6-1.amd64.rpm